### PR TITLE
Pause Spotify when video playback starts

### DIFF
--- a/modules/gui/macosx/intf.m
+++ b/modules/gui/macosx/intf.m
@@ -1455,6 +1455,15 @@ static VLCMain *_o_sharedMainInstance = nil;
             }
         }
 
+        // pause Spotify
+        int i_control_spotify = var_InheritBool(p_intf, "macosx-control-spotify");
+        if (i_control_spotify) {
+            SBApplication *spotifyApp = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
+            if ([spotifyApp isRunning] && [spotifyApp respondsToSelector:@selector(pause)]) {
+                msg_Dbg(p_intf, "Pause Spotify...");
+                [spotifyApp performSelector:@selector(pause)];
+            }
+        }
 
         /* Declare user activity.
          This wakes the display if it is off, and postpones display sleep according to the users system preferences

--- a/modules/gui/macosx/macosx.m
+++ b/modules/gui/macosx/macosx.m
@@ -124,6 +124,9 @@ void WindowClose  (vout_window_t *);
 #define ITUNES_TEXT N_("Pause iTunes during VLC playback")
 #define ITUNES_LONGTEXT N_("Pauses iTunes playback when VLC playback starts. If selected, iTunes playback will be resumed again if VLC playback is finished.")
 
+#define SPOTIFY_TEXT N_("Pause Spotify during VLC playback")
+#define SPOTIFY_LONGTEXT N_("Pauses Spotify playback when VLC playback starts.")
+
 static const int itunes_list[] =
     { 0, 1, 2 };
 static const char *const itunes_list_text[] = {
@@ -161,6 +164,7 @@ vlc_module_begin()
         add_bool("macosx-pause-minimized", false, PAUSE_MINIMIZED_TEXT, PAUSE_MINIMIZED_LONGTEXT, false)
         add_bool("macosx-lock-aspect-ratio", true, LOCK_ASPECT_RATIO_TEXT, LOCK_ASPECT_RATIO_TEXT, true)
         add_integer("macosx-control-itunes", 1, ITUNES_TEXT, ITUNES_LONGTEXT, false)
+        add_bool("macosx-control-spotify", true, SPOTIFY_TEXT, SPOTIFY_LONGTEXT, false)
         change_integer_list(itunes_list, itunes_list_text)
 
     set_section(N_("Apple Remote and media keys"), 0)


### PR DESCRIPTION
Spotify does not have an API to query it for whether or not it is currently playing something, which means we can’t resume Spotify playback after video has finished (since we do not know if we actually did stop Spotify, or if it was already in a stopped state).

I was unsure about the last argument to `add_bool`.
