### PR TITLE
Build scripts: --enable-screen is a positive action, the description should match.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1876,7 +1876,7 @@ dnl  Screen capture module
 dnl
 AC_ARG_ENABLE(screen,
   [AS_HELP_STRING([--enable-screen],
-    [disable screen capture (default enabled)])])
+    [support screen captures (default enabled)])])
 if test "${enable_screen}" != "no"; then
   if test "${SYS}" = "darwin"; then
     AC_CHECK_HEADERS(ApplicationServices/ApplicationServices.h, [


### PR DESCRIPTION
Unlike the helper text suggests, --enable-screen obviously doesn't disable screen captures, but enables them.

Whether one should rather show "--disable-screen" (since per default it already is enabled) is a separate discussion, I guess.