### PR TITLE
fix: gui/qt4/Makefile.am can't be ignored

### DIFF
--- a/modules/gui/.gitignore
+++ b/modules/gui/.gitignore
@@ -1,1 +1,0 @@
-Makefile.am


### PR DESCRIPTION
I assume qt4/Makefile.am shouldn't be ignored?