### PR TITLE
Minor typo: Trickplay -> Trick play

### DIFF
--- a/modules/gui/qt4/components/controller.hpp
+++ b/modules/gui/qt4/components/controller.hpp
@@ -107,7 +107,7 @@ typedef enum buttonType_e
 static const char* const nameL[BUTTON_MAX] = { N_("Play"), N_("Stop"), N_("Open"),
     N_("Previous / Backward"), N_("Next / Forward"), N_("Slower"), N_("Faster"), N_("Fullscreen"),
     N_("De-Fullscreen"), N_("Extended panel"), N_("Playlist"), N_("Snapshot"),
-    N_("Record"), N_("A→B Loop"), N_("Frame By Frame"), N_("Trickplay Reverse"),
+    N_("Record"), N_("A→B Loop"), N_("Frame By Frame"), N_("Trick play Reverse"),
     N_("Step backward" ), N_("Step forward"), N_("Quit"), N_("Random"),
     N_("Loop / Repeat"), N_("Information"), N_("Previous"), N_("Next"),
     N_("Open subtitles"), N_("Dock fullscreen controller")


### PR DESCRIPTION
Seems like trickplay should be split into two words according to i.e. http://en.wikipedia.org/wiki/Trick_mode
If split into two words, the NEWS should reflect this as well - https://github.com/videolan/vlc/blob/master/NEWS