### PR TITLE
Move appcast feed to SSL

### DIFF
--- a/extras/package/macosx/Info.plist.in
+++ b/extras/package/macosx/Info.plist.in
@@ -1380,7 +1380,7 @@
 		</dict>
 	</array>
 	<key>SUFeedURL</key>
-	<string>http://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
+	<string>https://update.videolan.org/vlc/sparkle/vlc-intel64.xml</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
See https://vulnsec.com/2016/osx-apps-vulnerabilities/

You should really use https to host appcast feed.