### PR TITLE
snap: add proper indicator support

### DIFF
--- a/extras/package/snap/snapcraft.yaml
+++ b/extras/package/snap/snapcraft.yaml
@@ -141,7 +141,12 @@ parts:
       - wayland-protocols
       - zlib1g-dev
       - zsh
-    after: [desktop-qt5]
+    after:
+      - desktop-qt5
+      - indicator-qt5
+
+  desktop-qt5:
+    stage: [ -./**/lib/*/qt5/**/libappmenu-qt5.so ]
 
   env:
     plugin: nil


### PR DESCRIPTION
Properly support icons in indicators, by using the indicator-qt5 remote part.