### PR TITLE
Updated README links and proposed .github template suggestions

### DIFF
--- a/.github/ISSUES_TEMPLATE.md
+++ b/.github/ISSUES_TEMPLATE.md
@@ -1,0 +1,1 @@
+**All pull requests are ignored, please follow https://wiki.videolan.org/Sending_Patches_VLC/**

--- a/.github/ISSUES_TEMPLATE.md
+++ b/.github/ISSUES_TEMPLATE.md
@@ -1,1 +1,1 @@
-**All pull requests are ignored, please follow https://wiki.videolan.org/Sending_Patches_VLC/**
+**All issues are ignored, please follow https://www.videolan.org/support/**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+**All pull requests are ignored, please follow https://wiki.videolan.org/Sending_Patches_VLC/**

--- a/README
+++ b/README
@@ -15,14 +15,14 @@ been downloaded close to one billion times.
 Links:
 ======
 
-The VLC web site  . . . . . http://www.videolan.org/
-Support . . . . . . . . . . http://www.videolan.org/support/
-Forums  . . . . . . . . . . http://forum.videolan.org/
-Wiki  . . . . . . . . . . . http://wiki.videolan.org/
-The Developers site . . . . http://wiki.videolan.org/Developers_Corner
-VLC hacking guide . . . . . http://wiki.videolan.org/Hacker_Guide
-Bugtracker  . . . . . . . . http://trac.videolan.org/vlc/
-The VideoLAN web site . . . http://www.videolan.org/
+The VLC web site  . . . . . https://www.videolan.org/vlc/
+Support . . . . . . . . . . https://www.videolan.org/support/
+Forums  . . . . . . . . . . https://forum.videolan.org/
+Wiki  . . . . . . . . . . . https://wiki.videolan.org/
+The Developers site . . . . https://wiki.videolan.org/Developers_Corner
+VLC hacking guide . . . . . https://wiki.videolan.org/Hacker_Guide
+Bugtracker  . . . . . . . . https://trac.videolan.org/vlc/
+The VideoLAN web site . . . https://www.videolan.org/
 
 Source Code Content:
 ===================


### PR DESCRIPTION
Updated all HTTP links to reflect the current HTTPS URLs and changed the redundant VLC website link from the VideoLAN landing page to the VLC subdirectory.

I also made some suggestions as to some .github templates you can use to better redirect users through the more appropriate channels for support and making pull requests.

I can't currently submit this patch through the appropriate channels as described in the documentation/checklist, but in the spirit of open source anyone who wants to make a perfectly valid git patch for any of these changes and mail it in is perfectly welcomed to do so. Just let me know what you included in your patch and I'll update and/or close this when you've sent it. You can also reference this PR if you feel so obliged to do so.

I would also mention to the project maintainers there are services such as nopullrequests.com to also ensure you're not racking up unnecessary and unwanted PRs.