### PR TITLE
snapcraft: add indicator-qt5-from-src to fix missing indicator icon

### DIFF
--- a/extras/package/snap/snapcraft.yaml
+++ b/extras/package/snap/snapcraft.yaml
@@ -34,7 +34,9 @@ apps:
 
 parts:
   vlc:
-    after: [desktop-qt5]
+    after:
+      - desktop-qt5
+      - indicator-qt5-from-src
     source: ../../../
     source-type: git
     plugin: autotools
@@ -223,6 +225,9 @@ parts:
       - zlib1g
       - libprojectm2v5
       - projectm-data
+
+  desktop-qt5:
+    stage: [ -./**/lib/*/qt5/**/libappmenu-qt5.so ]
 
   wrapper:
     plugin: dump


### PR DESCRIPTION
As per bug https://trac.videolan.org/vlc/ticket/19692 using the remote part [indicator-qt5-from-src](https://github.com/3v1n0/appindicators-snapcraft-parts) will fix the issue of the VLC indicator not showing its icon when installed from snap package.