### PR TITLE
Fix share/lua/README.txt HTTPd documentation

### DIFF
--- a/share/lua/README.txt
+++ b/share/lua/README.txt
@@ -99,11 +99,11 @@ Extension
 ---------
 deactivate(): Deactivate current extension (after the end of the current function).
 
-HTTPd
------
-http( host, port, [cert, key, ca, crl]): create a new HTTP (SSL) daemon.
+HTTPd (only usable for interfaces)
+----------------------------------
+httpd(): create a new HTTP daemon.
 
-local h = vlc.httpd( "localhost", 8080 )
+local h = vlc.httpd()
 h:handler( url, user, password, callback, data ) -- add a handler for given url. If user and password are non nil, they will be used to authenticate connecting clients. callback will be called to handle connections. The callback function takes 7 arguments: data, url, request, type, in, addr, host. It returns the reply as a string.
 h:file( url, mime, user, password, callback, data ) -- add a file for given url with given mime type. If user and password are non nil, they will be used to authenticate connecting clients. callback will be called to handle connections. The callback function takes 2 arguments: data and request. It returns the reply as a string.
 h:redirect( url_dst, url_src ): Redirect all connections from url_src to url_dst.


### PR DESCRIPTION
According to my own code review and testing, the vlc.httpd() Lua method does not take any arguments and neither support HTTPS in the current VLC version 3.0.3. Also, the documentation doesn't make it clear on what type of Lua modules it's available, when it can only be used in the context of interfaces.

These code snippets support the findings mentioned above:

- [Code responsible for HTTPd daemon availability on Lua interfaces](https://github.com/videolan/vlc/blob/master/modules/lua/intf.c#L258) (note that a similar call is not present for [extensions](https://github.com/videolan/vlc/blob/master/modules/lua/extension.c#L830)).
- [vlc.httpd() implementation](https://github.com/videolan/vlc/blob/master/modules/lua/libs/httpd.c#L82) (notice how it doesn't read any arguments passed to the function and always calls `vlc_http_HostNew`. This results in a [HTTP server daemon being created](https://github.com/videolan/vlc/blob/master/src/network/httpd.c#L869) on the configured host and port, without TLS information passed, so no HTTPS support is available.