### PR TITLE
Cleanup: Minor package and API update to snapcraft.yaml

### DIFF
--- a/extras/package/snap/snapcraft.yaml
+++ b/extras/package/snap/snapcraft.yaml
@@ -57,9 +57,8 @@ parts:
     source: ../../../
     source-type: git
     plugin: autotools
-    prepare: |
+    override-build: |
       sed -i 's|0\.19\.8|0\.19\.7|'  configure.ac
-    build: |
       cd extras/tools
       ./bootstrap
       make -j $(getconf _NPROCESSORS_ONLN) .protoc
@@ -84,7 +83,6 @@ parts:
           --disable-wayland \
           --enable-merge-ffmpeg
       make -j $(getconf _NPROCESSORS_ONLN)
-    install: |
       echo $(git describe HEAD) > $SNAPCRAFT_STAGE/version
       make install
       sed -i 's|Icon=vlc|Icon=/usr/share/icons/hicolor/256x256/apps/vlc\.png|' $SNAPCRAFT_PART_INSTALL/usr/share/applications/vlc.desktop
@@ -162,6 +160,7 @@ parts:
       - libfreerdp-gdi1.1
       - libfreetype6
       - libfribidi0
+      - libdb5.3
       - libgcc1
       - libgl1-mesa-glx
       - libgles2-mesa


### PR DESCRIPTION
These updates were after trying to get native theming support for the snaps to work based on the changes done on the Thunderbird and LibreOffice snaps.

I tried adding a theming fix in data-dir work around as part of https://github.com/snapcore/snapd/pull/5395 and the themes were successfully loaded into the snap.

The issue is that it appears to not work as I don't think vlc uses libgtk-3-0 to be able to use GTK-3 themes. I tried various environment variables suggested by various forums to get QT to use the gtk themes but none of them really worked.

Whilst using the vlc docker to build the snap, certain aspects of the snap appear to be outdated. For example, prepare, build and install has now been deprecated in trade of override-build.

That and vlc snap appeared to be pulling pacakges from the container which may soon be deprecated too.

If the snap interface theming support evolves, I will try again then.