### PR TITLE
snap: Set the AppStream ID in the Snap metadata

### DIFF
--- a/extras/package/snap/snapcraft.yaml
+++ b/extras/package/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ confinement: strict
 apps:
   vlc:
     desktop: usr/share/applications/vlc.desktop
+    common-id: org.videolan.vlc
     command: desktop-launch $SNAP/bin/vlc-snap-wrapper.sh
     plugs:
       - unity7


### PR DESCRIPTION
This allows software store to recognise this snap matches VLC in other
formats (.deb, .rpm, Flatpak etc). It also means reviews on ODRS are
grouped together.