### PR TITLE
Corrected youtube example url

### DIFF
--- a/modules/gui/qt/ui/open_net.ui
+++ b/modules/gui/qt/ui/open_net.ui
@@ -44,7 +44,7 @@
 rtp://@:1234
 mms://mms.examples.com/stream.asx
 rtsp://server.example.org:8080/test.sdp
-http://www.yourtube.com/watch?v=gg64x</string>
+http://www.youtube.com/watch?v=gg64x</string>
         </property>
         <property name="margin">
          <number>5</number>


### PR DESCRIPTION
Just noticed this typo in the VLC ui (unless it's intentional) and decided to correct this (should it also be changed to `https://`?). I also noticed this same typo in the `.po` files. Are those generated or does this need to be applied there as well?