### PR TITLE
Fix for buffer overflow in access_out/rist.c

### DIFF
--- a/modules/access_output/rist.c
+++ b/modules/access_output/rist.c
@@ -338,7 +338,7 @@ static void rist_rtcp_recv(sout_access_out_t *p_access, struct rist_flow *flow, 
                     if (p_sys->b_ismulticast == false)
                     {
                         int8_t name_length = rtcp_sdes_get_name_length(pkt);
-                        if (name_length > bytes_left)
+                        if (name_length > bytes_left || name_length >= MAX_CNAME )
                         {
                             /* check for a sane number of bytes */
                             msg_Err(p_access, "Malformed SDES packet, wrong cname len %u, got a " \


### PR DESCRIPTION
Checks were added to `name_length` before it was used as an argument to memcpy. 

**Checks added:** 
`name_length >= MAX_CNAME ` 

