### PR TITLE
context_wait return is a bool - return true or false

### DIFF
--- a/modules/audio_output/vlcpulse.c
+++ b/modules/audio_output/vlcpulse.c
@@ -64,10 +64,10 @@ static bool context_wait (pa_context *ctx, pa_threaded_mainloop *mainloop)
     while ((state = pa_context_get_state (ctx)) != PA_CONTEXT_READY)
     {
         if (state == PA_CONTEXT_FAILED || state == PA_CONTEXT_TERMINATED)
-            return -1;
+            return false;
         pa_threaded_mainloop_wait (mainloop);
     }
-    return 0;
+    return true;
 }
 
 static void context_event_cb(pa_context *c, const char *name, pa_proplist *pl,


### PR DESCRIPTION
context_wait was returning -1 or 0.

The method signature calls for a bool return of true or false.