### PR TITLE
stream_filter: fix null dereference by modules/demux/mpeg/ts.c

### DIFF
--- a/src/input/stream_filter.c
+++ b/src/input/stream_filter.c
@@ -43,7 +43,8 @@ static void StreamDelete(stream_t *s)
     struct vlc_stream_filter_private *priv = vlc_stream_Private(s);
 
     module_unneed(s, priv->module);
-    vlc_stream_Delete(s->s);
+    if( s->s != NULL )
+        vlc_stream_Delete(s->s);
     free(s->psz_filepath);
 }
 


### PR DESCRIPTION
This revers commit daeddd9bc724da5aa3c364c5b382da963f92b5b8
("stream_filter: remove tautology test").

The close callback for MPEG Transport Stream demuxer module sets the
b25stream's input stream to NULL and deletes the b25stream by calling
vlc_stream_Delete() which ends up calling StreamDelete().
(See /* don't chain kill demuxer's source */ comment in
modules/demux/mpeg/ts.c)

This change restores the test against NULL input stream in StreamDelete()
to avoid NULL dereference.