### PR TITLE
fix invalid unsigned arithmetic.

### DIFF
--- a/modules/codec/telx.c
+++ b/modules/codec/telx.c
@@ -699,7 +699,7 @@ static int Decode( decoder_t *p_dec, block_t *p_block )
             memcpy( pt, p_sys->ppsz_lines[i], l );
             total += l;
             pt += l;
-            if ( sizeof(psz_text) - total - 1 > 0 )
+            if ( sizeof(psz_text) > total + 1 )
             {
                 *pt++ = '\n';
                 total++;


### PR DESCRIPTION
your check is incorrect. since the variables are unsigned, it is equivalent to sizeof(psz_text) != total + 1.
so I suggest a simple fix for the error.