### PR TITLE
lua: fix EACCES error name in README

### DIFF
--- a/share/lua/README.txt
+++ b/share/lua/README.txt
@@ -90,7 +90,7 @@ errno
 List of potential errors. It contains the following values:
   .ENOENT: No such file or directory
   .EEXIST: File exists
-  .EACCESS: Permission denied
+  .EACCES: Permission denied
   .EINVAL: Invalid argument
 
 


### PR DESCRIPTION
The error name is `EACCES` (as confusing as that is), [as seen here](https://github.com/videolan/vlc/blob/02c95ad3816366ea2a4da4a599ba7e53545ef4e6/modules/lua/libs/errno.c).