### PR TITLE
disable wayland in snaps

### DIFF
--- a/extras/package/snap/snapcraft.yaml
+++ b/extras/package/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ apps:
     desktop: usr/share/applications/vlc.desktop
     command: bin/desktop-launch $SNAP/bin/vlc-snap-wrapper.sh
     common-id: org.videolan.vlc
+    environment:
+      DISABLE_WAYLAND: '1'
     plugs:
       - unity7
       - network


### PR DESCRIPTION
The snap version of VLC 4.0 dev cannot run in wayland. So, disable it by default.