### PR TITLE
fix typo in open_net.ui

### DIFF
--- a/modules/gui/qt/dialogs/open/open_net.ui
+++ b/modules/gui/qt/dialogs/open/open_net.ui
@@ -44,7 +44,7 @@
 rtp://@:1234
 mms://mms.examples.com/stream.asx
 rtsp://server.example.org:8080/test.sdp
-http://www.yourtube.com/watch?v=gg64x</string>
+http://www.youtube.com/watch?v=gg64x</string>
         </property>
         <property name="margin">
          <number>5</number>


### PR DESCRIPTION
Change the url from yourtube.com (which seems to be a scam link) to the official YouTube url.