### PR TITLE
Fix Typos in Documentation Files

### DIFF
--- a/doc/clock.md
+++ b/doc/clock.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document presents the new clock archictecture for **VLC**, starting from
+This document presents the new clock architecture for **VLC**, starting from
 VLC 4.0.
 
 The clock is the element that manages the synchronisation of all [ES][ES],

--- a/doc/vlm.txt
+++ b/doc/vlm.txt
@@ -34,7 +34,7 @@ III - Command line syntax:
 Note: an element is a media or a schedule.
  1) Command lines:
     help
-        Displays an exhaustive commmand lines list.
+        Displays an exhaustive command lines list.
 
     new (name) broadcast|schedule [properties]
         Creates a new element. You must specify if a broadcast media, or
@@ -66,7 +66,7 @@ Note: an element is a media or a schedule.
         See Commands section for more information.
     save (config_file)
         Saves all media and schedule configurations in the (config_file)
-        configuration file. the "save" command overwrites the file if it
+        configuration file. The "save" command overwrites the file if it
         already exists. States (playing, paused, stop) are not saved.
         See Configuration File section for more information.
     load (config_file)
@@ -75,7 +75,7 @@ Note: an element is a media or a schedule.
 
  2) Properties:
  Note: except the "append" property, all property can be followed by
- another one, recursively.For example:
+ another one, recursively. For example:
  "setup pouet input file://arf.avi output udp:127.0.0.1 enabled loop"
  is a valid command line.
     Media Properties Syntax:


### PR DESCRIPTION
This pull request addresses and fixes typos in the documentation files. The changes include:

- Corrected "commmand" to "command" in `vlc/doc/vlm.txt`
- Fixed "archictecture" to "architecture" in `doc/clock.md`

These corrections ensure that the documentation is clear and accurate, improving readability and understanding.
