### PR TITLE
demux: mp4: only return true in GetMoofTrackDuration with a duration 

### DIFF
--- a/modules/demux/mp4/mp4.c
+++ b/modules/demux/mp4/mp4.c
@@ -4773,10 +4773,10 @@ static bool GetMoofTrackDuration( MP4_Box_t *p_moov, MP4_Box_t *p_moof,
         }
 
         *p_duration = i_traf_duration;
-        break;
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 static int ProbeFragments( demux_t *p_demux, bool b_force, bool *pb_fragmented )

--- a/modules/demux/mp4/mp4.h
+++ b/modules/demux/mp4/mp4.h
@@ -139,7 +139,7 @@ typedef struct
     stime_t          i_next_dts;
     int64_t          i_cts_shift;
     vlc_tick_t       i_pts_offset;
-    stime_t          i_decoder_delay;
+    stime_t          i_decoder_delay; /* track timescale */
     /* give the next sample to read, i_chunk is to find quickly where
       the sample is located */
     uint32_t         i_sample;       /* next sample to read */


### PR DESCRIPTION
In pratice the value is never uninitialized in the loop.

Also add a comment about the `i_decoder_delay` scale.