### PR TITLE
Add temporary playback speed boost on key hold

### DIFF
--- a/modules/gui/qt/maininterface/videosurface.cpp
+++ b/modules/gui/qt/maininterface/videosurface.cpp
@@ -203,10 +203,29 @@ void VideoSurface::mouseDoubleClickEvent(QMouseEvent* event)
         event->ignore();
 }
 
+static float prev_rate = 1.0;
+static bool isBoosting = false;
+static int triggerKey = Qt::Key_Shift;
+static float boostRate = 2.0;
+
 void VideoSurface::keyPressEvent(QKeyEvent* event)
 {
-    emit keyPressed(event->key(), event->modifiers());
-    event->ignore();
+
+    if (!isBoosting && event->key() == triggerKey) {
+        prev_rate = this->p_intf->p_playerController->getRate();
+        this->p_intf->p_playerController->setRate(boostRate);
+        isBoosting = true;
+    }
+    QWidget::keyPressEvent(event);
+}
+
+void VideoSurface::keyReleaseEvent(QKeyEvent *event)
+{
+    if (isBoosting && event->key() == triggerKey) {
+        this->p_intf->p_playerController->setRate(prev_rate);
+        isBoosting = false;
+    }
+    QWidget::keyReleaseEvent(event);
 }
 
 #if QT_CONFIG(wheelevent)


### PR DESCRIPTION
This PR introduces a temporary playback speed boost feature.

When the user presses and holds a key (default: Shift), playback speed increases (default: 2x). When the key is released, the playback speed returns to its previous value.

Implementation details:
- Handled key press and release events in VideoSurface
- Stored previous playback rate before applying boost
- Used a flag to prevent repeated triggering
- Restored original playback rate on key release

This improves usability by allowing quick temporary speed-up during playback.